### PR TITLE
Set up background service to advance scenes

### DIFF
--- a/lib/background-service.ts
+++ b/lib/background-service.ts
@@ -1,0 +1,25 @@
+// Background job needs to:
+//
+// - Be serializable
+// - Be restartable, optionally with new data
+// - Watches out-of-band light changes and uses them as overrides
+// - Set up an API to clear current overrides list (just call restart?)
+
+import * as path from 'path'
+
+let sp: string
+
+function serializationPath() {
+  if (sp) return sp
+
+  // NB: Accessing process.env can actually be stupidly slow
+  return (sp = path.join(process.env.HA_LIGHTING_ROOT ?? '.', 'storage.json'))
+}
+
+export async function start() {
+  // Connect to HA
+  // Foreach scene pair:
+  // - Subscribe to sensor and affected lights/switches
+}
+
+export async function stop() {}


### PR DESCRIPTION
This PR sets up our ongoing background service that knows how to load/save itself, as well as actually watch the relevant Home Assistant entities to actually Make The App Work